### PR TITLE
Remove Fx from server implementation

### DIFF
--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -23,6 +23,7 @@ import (
 
 	casm "github.com/wetware/casm/pkg"
 	"github.com/wetware/ww"
+	cmdstart "github.com/wetware/ww/internal/cmd/start"
 	"github.com/wetware/ww/pkg/anchor"
 	"github.com/wetware/ww/pkg/server"
 	"github.com/wetware/ww/system"
@@ -67,7 +68,10 @@ func main() {
 		Copyright:            "2020 The Wetware Project",
 		EnableBashCompletion: true,
 		Flags:                flags,
-		Action:               action(),
+		Commands: []*cli.Command{
+			cmdstart.Command(),
+		},
+		Action: action(),
 	}
 
 	if err := app.RunContext(ctx, os.Args); err != nil {

--- a/internal/cmd/start/start.go
+++ b/internal/cmd/start/start.go
@@ -2,108 +2,96 @@ package start
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"runtime"
+	"strings"
 
 	"github.com/lthibault/log"
-
 	"github.com/urfave/cli/v2"
-	"go.uber.org/fx"
-
-	ww_runtime "github.com/wetware/ww/pkg/runtime"
+	"github.com/wetware/ww/server"
 )
 
-var (
-	app    *fx.App
-	logger log.Logger
-)
-
-var flags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    "ns",
-		Usage:   "cluster namespace",
-		Value:   "ww",
-		EnvVars: []string{"WW_NS"},
-	},
-	&cli.StringSliceFlag{
-		Name:    "listen",
-		Aliases: []string{"l"},
-		Usage:   "host listen address",
-		Value: cli.NewStringSlice(
-			"/ip4/0.0.0.0/udp/0/quic",
-			"/ip6/::0/udp/0/quic"),
-		EnvVars: []string{"WW_LISTEN"},
-	},
-	&cli.StringSliceFlag{
-		Name:    "addr",
-		Aliases: []string{"a"},
-		Usage:   "static bootstrap `ADDR`",
-		EnvVars: []string{"WW_ADDR"},
-	},
-	&cli.StringFlag{
-		Name:    "discover",
-		Aliases: []string{"d"},
-		Usage:   "bootstrap discovery multiaddr",
-		Value:   bootstrapAddr(),
-		EnvVars: []string{"WW_DISCOVER"},
-	},
-	&cli.StringSliceFlag{
-		Name:    "meta",
-		Usage:   "metadata fields in key=value format",
-		EnvVars: []string{"WW_META"},
-	},
-}
+var meta map[string]string
 
 // Command constructor
 func Command() *cli.Command {
 	return &cli.Command{
-		Name:   "start",
-		Usage:  "start a host process",
-		Flags:  flags,
-		Before: setup(),
-		Action: serve(),
-		After:  teardown(),
+		Name:  "start",
+		Usage: "start a host process",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "ns",
+				Usage:   "cluster namespace",
+				Value:   "ww",
+				EnvVars: []string{"WW_NS"},
+			},
+			&cli.StringSliceFlag{
+				Name:    "listen",
+				Aliases: []string{"l"},
+				Usage:   "host listen address",
+				Value: cli.NewStringSlice(
+					"/ip4/0.0.0.0/udp/0/quic",
+					"/ip6/::0/udp/0/quic"),
+				EnvVars: []string{"WW_LISTEN"},
+			},
+			&cli.StringSliceFlag{
+				Name:    "join",
+				Aliases: []string{"j"},
+				Usage:   "join cluster via existing peer `ADDR`",
+				EnvVars: []string{"WW_JOIN"},
+			},
+			&cli.StringFlag{
+				Name:    "discover",
+				Aliases: []string{"d"},
+				Usage:   "multiaddr of peer-discovery service",
+				Value:   bootstrapAddr(),
+				EnvVars: []string{"WW_DISCOVER"},
+			},
+			&cli.StringSliceFlag{
+				Name:    "meta",
+				Usage:   "metadata fields in key=value format",
+				EnvVars: []string{"WW_META"},
+			},
+		},
+		Before: bindMeta(),
+		Action: func(c *cli.Context) error {
+			config := server.Config{
+				Logger:   log.New(),
+				NS:       c.String("ns"),
+				Join:     c.StringSlice("join"),
+				Discover: c.String("discover"),
+				Meta:     meta,
+			}
+
+			err := config.ListenAndServe(c.Context, c.StringSlice("listen")...)
+			if err != context.Canceled {
+				return err
+			}
+
+			return nil
+		},
 	}
 }
 
-func setup() cli.BeforeFunc {
+func bindMeta() cli.BeforeFunc {
 	return func(c *cli.Context) error {
-		app = fx.New(
-			ww_runtime.NewServer(c.Context, c),
-			fx.Populate(&logger))
+		metaTags := c.StringSlice("meta")
 
-		return start(c.Context, app)
-	}
-}
+		for _, tag := range metaTags {
+			pair := strings.SplitN(tag, "=", 2)
+			if len(pair) != 2 {
+				return fmt.Errorf("invalid meta tag: %s", tag)
+			}
 
-func serve() cli.ActionFunc {
-	return func(*cli.Context) error {
-		logger.Info("wetware started")
+			if meta == nil {
+				meta = make(map[string]string, len(metaTags))
+			}
 
-		signal := <-app.Done()
-		logger.
-			WithField("signal", signal).
-			Warn("shutdown signal received")
+			meta[pair[0]] = pair[1]
+		}
 
 		return nil
-	}
-}
-
-func start(ctx context.Context, app *fx.App) error {
-	ctx, cancel := context.WithTimeout(ctx, app.StartTimeout())
-	defer cancel()
-
-	return app.Start(ctx)
-}
-
-func teardown() cli.AfterFunc {
-	return func(c *cli.Context) error {
-		ctx, cancel := context.WithTimeout(
-			context.Background(),
-			app.StopTimeout())
-		defer cancel()
-
-		return app.Stop(ctx)
 	}
 }
 

--- a/internal/cmd/start/start.go
+++ b/internal/cmd/start/start.go
@@ -54,27 +54,31 @@ func Command() *cli.Command {
 				EnvVars: []string{"WW_META"},
 			},
 		},
-		Before: bindMeta(),
-		Action: func(c *cli.Context) error {
-			config := server.Config{
-				Logger:   log.New(),
-				NS:       c.String("ns"),
-				Join:     c.StringSlice("join"),
-				Discover: c.String("discover"),
-				Meta:     meta,
-			}
-
-			err := config.ListenAndServe(c.Context, c.StringSlice("listen")...)
-			if err != context.Canceled {
-				return err
-			}
-
-			return nil
-		},
+		Before: setup(),
+		Action: start(),
 	}
 }
 
-func bindMeta() cli.BeforeFunc {
+func start() cli.ActionFunc {
+	return func(c *cli.Context) error {
+		config := server.Config{
+			Logger:   log.New(),
+			NS:       c.String("ns"),
+			Join:     c.StringSlice("join"),
+			Discover: c.String("discover"),
+			Meta:     meta,
+		}
+
+		err := config.ListenAndServe(c.Context, c.StringSlice("listen")...)
+		if err != context.Canceled {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func setup() cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		metaTags := c.StringSlice("meta")
 

--- a/server/cluster.go
+++ b/server/cluster.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/libp2p/go-libp2p-kad-dht/dual"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/wetware/casm/pkg/cluster"
+	"github.com/wetware/casm/pkg/cluster/pulse"
+	"github.com/wetware/casm/pkg/cluster/routing"
+)
+
+type clusterConfig struct {
+	Host      host.Host
+	PubSub    *pubsub.PubSub
+	Discovery discovery.Discovery
+	DHT       *dual.DHT
+}
+
+func (cfg Config) newCluster(ctx context.Context, cc clusterConfig) (*cluster.Router, error) {
+	rt := routing.New(time.Now())
+
+	err := cc.PubSub.RegisterTopicValidator(cfg.NS, pulse.NewValidator(rt))
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := cc.PubSub.Join(cfg.NS)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cluster.Router{
+		Topic:        t,
+		Log:          cfg.Logger,
+		Meta:         cfg.preparer(),
+		RoutingTable: rt,
+	}, nil
+}
+
+type metaFieldSlice []routing.MetaField
+
+func (cfg Config) preparer() pulse.Preparer {
+	fs := make(metaFieldSlice, 0, len(cfg.Meta))
+
+	for key, value := range cfg.Meta {
+		fs = append(fs, routing.MetaField{
+			Key:   key,
+			Value: value,
+		})
+	}
+
+	return fs
+}
+
+func (m metaFieldSlice) Prepare(h pulse.Heartbeat) error {
+	if err := h.SetMeta(m); err != nil {
+		return err
+	}
+
+	// hostname may change over time
+	host, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	return h.SetHost(host)
+}

--- a/server/discovery.go
+++ b/server/discovery.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"io"
+
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/wetware/casm/pkg/boot"
+	"github.com/wetware/casm/pkg/boot/socket"
+	bootutil "github.com/wetware/casm/pkg/boot/util"
+)
+
+func (cfg Config) newBootstrapper(h host.Host) (*bootService, error) {
+	var d discovery.Discovery
+	var err error
+	if len(cfg.Join) > 0 {
+		d, err = boot.NewStaticAddrStrings(cfg.Join...)
+	} else {
+		d, err = bootutil.ListenString(h, cfg.Discover,
+			socket.WithLogger(cfg.Logger),
+			socket.WithRateLimiter(socket.NewPacketLimiter(256, 16)))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &bootService{Discovery: d}, nil
+}
+
+type bootService struct{ discovery.Discovery }
+
+func (d bootService) Close() (err error) {
+	if c, ok := d.Discovery.(io.Closer); ok {
+		err = c.Close()
+	}
+
+	return
+}

--- a/server/discovery.go
+++ b/server/discovery.go
@@ -13,8 +13,8 @@ import (
 func (cfg Config) newBootstrapper(h host.Host) (*bootService, error) {
 	var d discovery.Discovery
 	var err error
-	if len(cfg.Join) > 0 {
-		d, err = boot.NewStaticAddrStrings(cfg.Join...)
+	if len(cfg.Peers) > 0 {
+		d, err = boot.NewStaticAddrStrings(cfg.Peers...)
 	} else {
 		d, err = bootutil.ListenString(h, cfg.Discover,
 			socket.WithLogger(cfg.Logger),

--- a/server/pubsub.go
+++ b/server/pubsub.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/libp2p/go-libp2p-kad-dht/dual"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
+	"github.com/lthibault/log"
+	"github.com/wetware/casm/pkg/boot"
+	protoutil "github.com/wetware/casm/pkg/util/proto"
+	ww "github.com/wetware/ww/pkg"
+)
+
+func (cfg Config) newPubSub(ctx context.Context, pc pubSubConfig) (*pubsub.PubSub, error) {
+	return pubsub.NewGossipSub(ctx, pc.Host,
+		pubsub.WithPeerExchange(true),
+		// pubsub.WithRawTracer(cfg.tracer()),
+		pubsub.WithDiscovery(pc.NewDiscovery(ctx)),
+		pubsub.WithProtocolMatchFn(cfg.protoMatchFunc()),
+		pubsub.WithGossipSubProtocols(cfg.subProtos()),
+		pubsub.WithPeerOutboundQueueSize(1024),
+		pubsub.WithValidateQueueSize(1024),
+	)
+}
+
+func (cfg Config) protoMatchFunc() pubsub.ProtocolMatchFn {
+	match := matcher(cfg.NS)
+
+	return func(local protocol.ID) func(protocol.ID) bool {
+		if match.Match(local) {
+			return match.Match
+		}
+
+		panic(fmt.Sprintf("match failed for local protocol %s", local))
+	}
+}
+
+func matcher(ns string) protoutil.MatchFunc {
+	proto, version := protoutil.Split(pubsub.GossipSubID_v11)
+	return protoutil.Match(
+		ww.NewMatcher(ns),
+		protoutil.Exactly(string(proto)),
+		protoutil.SemVer(string(version)))
+}
+
+func (cfg Config) subProtos() ([]protocol.ID, func(pubsub.GossipSubFeature, protocol.ID) bool) {
+	return []protocol.ID{protoID(cfg.NS)}, cfg.features()
+}
+
+func protoID(ns string) protocol.ID {
+	// FIXME: For security, the cluster topic should not be present
+	//        in the root pubsub capability server.
+
+	//        The cluster topic should instead be provided as an
+	//        entirely separate capability, negoaiated outside of
+	//        the PubSub cap.
+
+	// /casm/<casm-version>/ww/<version>/<ns>/meshsub/1.1.0
+	return protoutil.Join(
+		ww.Subprotocol(ns),
+		pubsub.GossipSubID_v11)
+}
+
+func (cfg Config) features() func(pubsub.GossipSubFeature, protocol.ID) bool {
+	supportGossip := matcher(cfg.NS)
+
+	_, version := protoutil.Split(protoID(cfg.NS))
+	supportsPX := protoutil.Suffix(version)
+
+	return func(feat pubsub.GossipSubFeature, proto protocol.ID) bool {
+		switch feat {
+		case pubsub.GossipSubFeatureMesh:
+			return supportGossip.Match(proto)
+
+		case pubsub.GossipSubFeaturePX:
+			return supportsPX.Match(proto)
+
+		default:
+			return false
+		}
+	}
+}
+
+type pubSubConfig struct {
+	Logger    log.Logger
+	NS        string
+	Host      host.Host
+	Discovery discovery.Discovery
+	DHT       *dual.DHT
+}
+
+func (cfg *pubSubConfig) NewDiscovery(ctx context.Context) *boot.Namespace {
+	// Dynamically dispatch advertisements and queries to either:
+	//
+	//  1. the bootstrap service, iff namespace matches cluster topic; else
+	//  2. the DHT-backed discovery service.
+	bootTopic := "floodsub:" + cfg.NS
+	match := func(ns string) bool {
+		return ns == bootTopic
+	}
+
+	target := loggingDiscovery{
+		Logger:    cfg.Logger,
+		Discovery: cfg.Discovery,
+	}
+
+	return &boot.Namespace{
+		Match:   match,
+		Target:  trimPrefixDisc{target},
+		Default: routing.NewRoutingDiscovery(cfg.DHT),
+	}
+}
+
+type loggingDiscovery struct {
+	Logger log.Logger
+	discovery.Discovery
+}
+
+func (b loggingDiscovery) FindPeers(ctx context.Context, ns string, opt ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	b.Logger.Debug("bootstrapping namespace")
+	return b.Discovery.FindPeers(ctx, ns, opt...)
+}
+
+func (b loggingDiscovery) Advertise(ctx context.Context, ns string, opt ...discovery.Option) (time.Duration, error) {
+	b.Logger.Debug("advertising namespace")
+	return b.Discovery.Advertise(ctx, ns, opt...)
+}
+
+// Trims the "floodsub:" prefix from the namespace.  This is needed because
+// clients do not use pubsub, and will search for the exact namespace string.
+type trimPrefixDisc struct{ discovery.Discovery }
+
+func (b trimPrefixDisc) FindPeers(ctx context.Context, ns string, opt ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	ns = strings.TrimPrefix(ns, "floodsub:")
+	return b.Discovery.FindPeers(ctx, ns, opt...)
+}
+
+func (b trimPrefixDisc) Advertise(ctx context.Context, ns string, opt ...discovery.Option) (time.Duration, error) {
+	ns = strings.TrimPrefix(ns, "floodsub:")
+	return b.Discovery.Advertise(ctx, ns, opt...)
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"context"
+
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-kad-dht/dual"
+	"github.com/libp2p/go-libp2p/core/host"
+	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
+	ww "github.com/wetware/ww/pkg"
+)
+
+func (cfg Config) withRouting(ctx context.Context, h host.Host) (*routedhost.RoutedHost, *dual.DHT, error) {
+	dht, err := cfg.newDHT(ctx, h)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return routedhost.Wrap(h, dht), dht, nil
+}
+
+func (cfg Config) newDHT(ctx context.Context, h host.Host) (*dual.DHT, error) {
+	// TODO:  Use dht.BootstrapPeersFunc to get bootstrap peers from PeX?
+	//        This might allow us to greatly simplify our architecture and
+	//        runtime initialization.  In particular:
+	//
+	//          1. The DHT could query PeX directly, eliminating the need for
+	//             dynamic dispatch via boot.Namespace.
+	//
+	//          2. The server.Joiner type could be simplified, and perhaps
+	//             eliminated entirely.
+
+	return dual.New(ctx, h,
+		dual.LanDHTOption(lanOpt(cfg.NS)...),
+		dual.WanDHTOption(wanOpt(cfg.NS)...))
+}
+
+func lanOpt(ns string) []dht.Option {
+	return []dht.Option{
+		dht.Mode(dht.ModeServer),
+		dht.ProtocolPrefix(ww.Subprotocol(ns)),
+		dht.ProtocolExtension("lan")}
+}
+
+func wanOpt(ns string) []dht.Option {
+	return []dht.Option{
+		dht.Mode(dht.ModeAuto),
+		dht.ProtocolPrefix(ww.Subprotocol(ns)),
+		dht.ProtocolExtension("wan")}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,7 @@ func (cfg Config) ListenAndServe(ctx context.Context, addrs ...string) error {
 	if err != nil {
 		return fmt.Errorf("listen: %w", err)
 	}
+	defer h.Close()
 
 	return cfg.Serve(ctx, h)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ import (
 type Config struct {
 	Logger   log.Logger
 	NS       string
-	Join     []string // static bootstrap peers
+	Peers    []string // static bootstrap peers
 	Discover string   // bootstrap service multiadr
 	Meta     map[string]string
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"capnproto.org/go/capnp/v3/rpc"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	quic "github.com/libp2p/go-libp2p/p2p/transport/quic"
+	tcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
+	"github.com/lthibault/log"
+	ww "github.com/wetware/ww/pkg"
+	"github.com/wetware/ww/pkg/anchor"
+	host_cap "github.com/wetware/ww/pkg/host"
+	"github.com/wetware/ww/pkg/pubsub"
+)
+
+type Config struct {
+	Logger   log.Logger
+	NS       string
+	Join     []string // static bootstrap peers
+	Discover string   // bootstrap service multiadr
+	Meta     map[string]string
+}
+
+func (cfg Config) ListenAndServe(ctx context.Context, addrs ...string) error {
+	h, err := libp2p.New(
+		libp2p.NoTransports,
+		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Transport(quic.NewTransport),
+		libp2p.ListenAddrStrings(addrs...))
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+
+	return cfg.Serve(ctx, h)
+}
+
+func (cfg Config) Serve(ctx context.Context, h host.Host) error {
+	if cfg.Logger == nil {
+		cfg.Logger = log.New()
+	}
+	cfg.Logger = cfg.Logger.WithField("ns", cfg.NS)
+
+	d, err := cfg.newBootstrapper(h)
+	if err != nil {
+		return fmt.Errorf("discovery: %w", err)
+	}
+	defer d.Close()
+
+	h, dht, err := cfg.withRouting(ctx, h)
+	if err != nil {
+		return fmt.Errorf("dht: %w", err)
+	}
+	defer dht.Close()
+
+	ps, err := cfg.newPubSub(ctx, pubSubConfig{
+		Logger:    cfg.Logger,
+		NS:        cfg.NS,
+		Host:      h,
+		Discovery: d,
+		DHT:       dht,
+	})
+	if err != nil {
+		return fmt.Errorf("pubsub: %w", err)
+	}
+
+	c, err := cfg.newCluster(ctx, clusterConfig{
+		Host:      h,
+		PubSub:    ps,
+		Discovery: d,
+		DHT:       dht,
+	})
+	if err != nil {
+		return fmt.Errorf("cluster: %w", err)
+	}
+	defer c.Stop()
+	defer ps.UnregisterTopicValidator(cfg.NS)
+
+	cfg.export(ctx, h, &host_cap.Server{
+		ViewProvider:   c,
+		AnchorProvider: &anchor.Node{},
+		PubSubProvider: &pubsub.Server{
+			Log:         cfg.Logger,
+			TopicJoiner: ps,
+		},
+	})
+
+	if err := c.Bootstrap(ctx); err != nil {
+		return fmt.Errorf("bootstrap: %w", err)
+	}
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (cfg Config) export(ctx context.Context, h host.Host, s *host_cap.Server) {
+	for _, proto := range []protocol.ID{
+		ww.Subprotocol(cfg.NS),
+		ww.Subprotocol(cfg.NS, "/packed"),
+	} {
+		h.SetStreamHandler(proto, cfg.handler(ctx, s))
+	}
+}
+
+func (cfg Config) handler(ctx context.Context, h *host_cap.Server) network.StreamHandler {
+	return func(s network.Stream) {
+		defer s.Close()
+
+		conn := rpc.NewConn(transport(s), &rpc.Options{
+			BootstrapClient: h.Client(),
+		})
+		defer conn.Close()
+
+		select {
+		case <-ctx.Done():
+		case <-conn.Done():
+		}
+	}
+}
+
+func transport(s network.Stream) rpc.Transport {
+	if strings.HasSuffix(string(s.Protocol()), "/packed") {
+		return rpc.NewPackedStreamTransport(s)
+	}
+
+	return rpc.NewStreamTransport(s)
+}


### PR DESCRIPTION
Embedding a Wetware server in a third-party application is currently tedious due to extensive boilerplate.  This boilerplate comes from three sources:

1. `pkg/server` uses Fx for dependency-injection but nonetheless requires us to instantiate, configure, start and stop the Fx application itself.
2. `server.Node` comprises multiple sub-services whose startup/shutdown logic logic needs to be carefully orchestrated.
3. Early iterations of Wetware focused heavily on configurability, so the public API for `pkg/server` exposes a lot of internals.

The goal of this PR is to provide a dead-simple mechanism for embedding servers.  It adds a top level `server/` package, within which all three sources of complexity are remedied as follows:

1. No use of Fx anywhere
2. Use of blocking `Serve` / `ListenAndServe` methods, similar to `net/http`
3. Reduced configuration options

A wetware server is now embedded as follows:

```go
// config file is designed to take simple types, which makes it
// easier to populate from CLI parameters.
config := server.Config{
	Logger:   log.New(),
	NS:       "my-namespace",
	Join:  <optional array of bootstrap peers>
	Discover: <optional multiaddr to discovery service>,
	Meta:     <optional map of key/value pairs>,
}

// blocks until the context expires; returns context's error
err := config.ListenAndServe(ctx, c.StringSlice("listen")...)
```

Contrary to the previous version, server capabilities are not directly accessible since there is no equivalent of the `server.Node` type.  Applications requiring access to the server's capability will have to dial a client connection to the local server.  Future work will facilitate this.