### PR TITLE
Cleanup boot logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-all: install
+all: clean install
 
 install:
 	go generate ./...
 	GOOS=wasip1 GOARCH=wasm gotip build -o rom/internal/main.wasm rom/internal/main.go
 	go install ./cmd/...
+
+clean:
+	@rm -f $(GOPATH)/bin/ww

--- a/guest/system/logging.go
+++ b/guest/system/logging.go
@@ -7,7 +7,10 @@ import (
 )
 
 func init() {
-	h := slog.NewJSONHandler(os.Stderr, nil)
+	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+
 	root := slog.New(h).With("rom", os.Args[0])
 	slog.SetDefault(root)
 }

--- a/system/logging.go
+++ b/system/logging.go
@@ -1,0 +1,32 @@
+package system
+
+import (
+	"os"
+
+	"golang.org/x/exp/slog"
+)
+
+func init() {
+	h := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+
+	root := slog.New(h).With("rom", os.Args[0])
+	slog.SetDefault(root)
+}
+
+// Logger is used for logging by the RPC system. Each method logs
+// messages at a different level, but otherwise has the same semantics:
+//
+//   - Message is a human-readable description of the log event.
+//   - Args is a sequenece of key, value pairs, where the keys must be strings
+//     and the values may be any type.
+//   - The methods may not block for long periods of time.
+//
+// This interface is designed such that it is satisfied by *slog.Logger.
+type Logger interface {
+	Debug(message string, args ...any)
+	Info(message string, args ...any)
+	Warn(message string, args ...any)
+	Error(message string, args ...any)
+}

--- a/system/system.go
+++ b/system/system.go
@@ -1,0 +1,36 @@
+package system
+
+import (
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/rpc"
+	local "github.com/libp2p/go-libp2p/core/host"
+	"github.com/urfave/cli/v2"
+	"github.com/wetware/pkg/client"
+)
+
+func Boot[T ~capnp.ClientKind](c *cli.Context, log Logger, h local.Host) (T, error) {
+	conn, err := dial(c, log, h)
+	if err != nil {
+		return T{}, err
+	}
+
+	go func() {
+		defer conn.Close()
+
+		select {
+		case <-c.Done():
+		case <-conn.Done():
+		}
+	}()
+
+	client := conn.Bootstrap(c.Context)
+	return T(client), client.Resolve(c.Context)
+}
+
+func dial(c *cli.Context, log Logger, h local.Host) (*rpc.Conn, error) {
+	return client.Dialer{
+		NS:       c.String("ns"),
+		Peers:    c.StringSlice("peer"),
+		Discover: c.String("discover"),
+	}.Dial(c.Context, h)
+}


### PR DESCRIPTION
This PR cleans up the bootstrapping logic for `v0.1.0`.

Currently, guest code can fetch a `host.Host` capability from the environment by calling `guest/system.Boot()`.  This adds an equivalent `system` for host code, with its own implementation of `Boot`.

In both cases, the `Boot` functions take a type parameter:  a bootstrap client.  We can now enforce correct typing of the bootstrap capability:  notice how `system.Boot[host.Host]` is distinct from `system.Boot[auth.Provider]`.

@mikelsr This is a small PR.  Technical feedback is most welcome :)